### PR TITLE
Sort the minutesbarchart of entire time by amount of minutes on leade…

### DIFF
--- a/frontend/src/components/shared/charts/BarChartPerPerson.jsx
+++ b/frontend/src/components/shared/charts/BarChartPerPerson.jsx
@@ -20,6 +20,11 @@ function BarChartMinutesPerPerson(props) {
             y: Object.keys(props.data),
             x: Object.values(props.data),
             orientation: "h",
+            transforms: [{
+              type: 'sort',
+              target: 'x',
+              order: 'ascending'
+            }]
           },
         ]}
         layout={{


### PR DESCRIPTION
Add "transforms" to BarChartMinutesPerPerson to sort the bars by the minutes.
"ascending" sorts the highest at the top:
![image](https://user-images.githubusercontent.com/44193165/116819582-f16be900-ab70-11eb-89b1-765130ac01eb.png)

@changdiqing @Apollo1840 Please review, thanks.