### PR TITLE
#33 Add new route to provide data for chart 'study events per week'

### DIFF
--- a/backend/studytimeboard/constant.py
+++ b/backend/studytimeboard/constant.py
@@ -39,6 +39,7 @@ N_STARS = "n_stars"
 MINUTES = "minutes"
 WEEKDAY = "weekday"
 ID_WEEK = "id_week"
+YEAR = "year"
 ORDERED_WEEKDAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
 WEEKDAY_COLORS = ["tab:pink", "tab:purple", "tab:blue", "tab:cyan", "tab:green", "tab:olive", "tab:orange"]
 

--- a/backend/studytimeboard/routes.py
+++ b/backend/studytimeboard/routes.py
@@ -163,8 +163,8 @@ def api_personal_durations():
         # error user not found?
         return {"status": "error", "message": FlashMessages.NO_SUCH_USER}, 401
 
-@app.route("/api/personal_study_events_per_week", methods=["GET"])
-def api_personal_study_events_per_week():
+@app.route("/api/personal_intervals_per_week", methods=["GET"])
+def api_personal_intervals_per_week():
     # TODO: Authentication with JWT
     df_all = get_df_ana(dbapi)
     authHeader = request.headers.get('jwt')

--- a/backend/studytimeboard/routes.py
+++ b/backend/studytimeboard/routes.py
@@ -163,6 +163,28 @@ def api_personal_durations():
         # error user not found?
         return {"status": "error", "message": FlashMessages.NO_SUCH_USER}, 401
 
+@app.route("/api/personal_study_events_per_week", methods=["GET"])
+def api_personal_study_events_per_week():
+    # TODO: Authentication with JWT
+    df_all = get_df_ana(dbapi)
+    authHeader = request.headers.get('jwt')
+    # TODO: decode user id from jwt token, for this we need user model with id, a DB to store user data
+    # and JWT, there is still a long way to go...
+    username = authHeader
+
+    # Check if name is found
+    if username in df_all[NAME].unique():
+        # TODO: move this to app_utils
+        df_user = df_all.loc[df_all[NAME] == username]
+        df_user = df_user.loc[df_user[END_TIME] != UNKNOWN]
+        durations_by_date = df_user[[START_TIME, END_TIME, ID_WEEK, YEAR]]
+        result_json = durations_by_date.to_json(orient="records")
+        # TODO: use JWT token
+        return {"status": "success", "data": json.loads(result_json)}, 200
+    else:
+        # error user not found?
+        return {"status": "error", "message": FlashMessages.NO_SUCH_USER}, 401
+
 
 # Minispec for authentication response:
 #   on success: response should contain token: String

--- a/backend/studytimeboard/utils/data_analysis.py
+++ b/backend/studytimeboard/utils/data_analysis.py
@@ -20,7 +20,8 @@ def add_analysis_columns(df):
     df[MINUTES] = [(t_end - t_start).seconds / 60 for t_start, t_end in zip(df[START_TIME_DT], df[END_TIME_DT])]
 
     df[DATE_DT] = pd.to_datetime(df[DATE])
-    df[ID_WEEK] = df[DATE_DT].dt.isocalendar().week  # todo: add year
+    df[ID_WEEK] = df[DATE_DT].dt.isocalendar().week
+    df[YEAR] = df[DATE_DT].dt.isocalendar().year
     df[WEEKDAY] = df[DATE_DT].dt.day_name()
 
     return df

--- a/frontend/src/services/TimeboardService.js
+++ b/frontend/src/services/TimeboardService.js
@@ -5,6 +5,7 @@ import {
   DURATIONS_TOTAL_URL,
   PERSONAL_DURATIONS_URL,
   PERSONAL_INTERVALS_URL,
+  PERSONAL_STUDY_EVENTS_PER_WEEK_URL
 } from "../shared/serverUrls.js";
 
 export default class TimeboardService {
@@ -61,6 +62,22 @@ export default class TimeboardService {
     return new Promise((resolve, reject) => {
       HttpService.get(
         SERVER_BASE_URL + PERSONAL_DURATIONS_URL,
+        (data) => {
+          resolve(data);
+        },
+        (errorMsg) => {
+          reject(errorMsg);
+        }
+      );
+    });
+  }
+
+  // Get logged intervals of current user of all time with calender week ID. Data from server contains start time, end time, week id and year. Date could
+  // be transfered only as string and must be converted to type `Date'.
+  static getPersonalStudyEventsPerWeek() {
+    return new Promise((resolve, reject) => {
+      HttpService.get(
+        SERVER_BASE_URL + PERSONAL_STUDY_EVENTS_PER_WEEK_URL,
         (data) => {
           resolve(data);
         },

--- a/frontend/src/services/TimeboardService.js
+++ b/frontend/src/services/TimeboardService.js
@@ -5,7 +5,7 @@ import {
   DURATIONS_TOTAL_URL,
   PERSONAL_DURATIONS_URL,
   PERSONAL_INTERVALS_URL,
-  PERSONAL_STUDY_EVENTS_PER_WEEK_URL
+  PERSONAL_INTERVALS_PER_WEEK_URL
 } from "../shared/serverUrls.js";
 
 export default class TimeboardService {
@@ -74,10 +74,10 @@ export default class TimeboardService {
 
   // Get logged intervals of current user of all time with calender week ID. Data from server contains start time, end time, week id and year. Date could
   // be transfered only as string and must be converted to type `Date'.
-  static getPersonalStudyEventsPerWeek() {
+  static getPersonalIntervalsPerWeek() {
     return new Promise((resolve, reject) => {
       HttpService.get(
-        SERVER_BASE_URL + PERSONAL_STUDY_EVENTS_PER_WEEK_URL,
+        SERVER_BASE_URL + PERSONAL_INTERVALS_PER_WEEK_URL,
         (data) => {
           resolve(data);
         },

--- a/frontend/src/shared/serverUrls.js
+++ b/frontend/src/shared/serverUrls.js
@@ -23,4 +23,5 @@ export const DURATIONS_TOTAL_URL = "/api/minutes_total";
 // personalanalysisview API
 export const PERSONAL_INTERVALS_URL = "/api/personal_intervals";
 export const PERSONAL_DURATIONS_URL = "/api/personal_durations";
+export const PERSONAL_STUDY_EVENTS_PER_WEEK_URL = "/api/personal_study_events_per_week";
 export const SERVER_BASE_URL = process.env.NODE_ENV === "development" ? SERVER_BASE_URL_DEV : SERVER_BASE_URL_PROD;

--- a/frontend/src/shared/serverUrls.js
+++ b/frontend/src/shared/serverUrls.js
@@ -23,5 +23,5 @@ export const DURATIONS_TOTAL_URL = "/api/minutes_total";
 // personalanalysisview API
 export const PERSONAL_INTERVALS_URL = "/api/personal_intervals";
 export const PERSONAL_DURATIONS_URL = "/api/personal_durations";
-export const PERSONAL_STUDY_EVENTS_PER_WEEK_URL = "/api/personal_study_events_per_week";
+export const PERSONAL_INTERVALS_PER_WEEK_URL = "/api/personal_intervals_per_week";
 export const SERVER_BASE_URL = process.env.NODE_ENV === "development" ? SERVER_BASE_URL_DEV : SERVER_BASE_URL_PROD;


### PR DESCRIPTION
I added a new route "/api/personal_study_events_per_week" to provide data for chart 'study events per week'.
Data contains start_time, end_time, id_week and year of the study events of the current user.